### PR TITLE
feat: add feedback feature with routes and model

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const PeopleTagRouter=require('./routes/PeopleTag.js')
 const CheckinRouter=require('./routes/CheckIn.js')
 const ProfileRouter=require('./routes/Profile.js')
 const SelfNoteRouter=require('./routes/SelfNote.js')
+const FeedbackRouter=require('./routes/Feedback.js')
 
 app.use(cors({
     origin:['http://localhost:5173','https://ru-ok.vercel.app'],
@@ -28,6 +29,7 @@ app.use('/api/activityTag',ActivityTagRouter)
 app.use('/api/peopleTag',PeopleTagRouter)
 app.use('/api/profile',ProfileRouter)
 app.use('/api/selfNote',SelfNoteRouter)
+app.use('/api/feedback',FeedbackRouter)
 
 connectDb().then(()=>{
     console.log("connected to database")

--- a/models/toolFeedback.js
+++ b/models/toolFeedback.js
@@ -1,0 +1,27 @@
+const mongoose = require('mongoose');
+const Schema = mongoose.Schema;
+
+const toolFeedbackSchema = new Schema({
+    userId:{
+        type:Schema.Types.ObjectId,
+        ref:'User',
+        required:true
+    },
+    toolName:{
+        type:String,
+        required:true
+    },
+    rating:{
+        type:Number,
+        required:true,
+        min:0,
+        max:100
+    },
+    checkIn:{
+        type:Schema.Types.ObjectId,
+        ref:'CheckIn',
+        required:true
+    }
+    },{timestamps:true}
+)
+module.exports=mongoose.model('ToolFeedback',toolFeedbackSchema)

--- a/routes/Feedback.js
+++ b/routes/Feedback.js
@@ -1,0 +1,67 @@
+const express = require('express');
+const router = express.Router()
+const userAuth=require('../middleware/userAuth')
+const ToolFeedback = require('../models/toolFeedback');
+const CheckIn = require('../models/checkIn');
+
+router.post('/new',userAuth,async (req,res)=>{
+    try{
+        const userId=req.user._id
+        const {toolName,rating,checkIn}=req.body
+
+        //verify checkin id
+        const isCheckin=await CheckIn.findById(checkIn)
+        if(!isCheckin){
+            return res.status(404).json({message:"Invalid Checkin Id"})
+        }
+
+        const newFeedback=await new ToolFeedback({
+            userId,
+            toolName,
+            rating,
+            checkIn
+        })
+
+        await newFeedback.save()
+
+        await newFeedback.populate({
+            path:'checkIn',
+            populate:[
+                {path:'emotion'},
+                {path:'activityTag'},
+                {path:'placeTag'},
+                {path:'peopleTag'}
+            ]
+        })
+
+
+        res.status(200).json({message:"Successfully created new Feedback",data:newFeedback})
+    }
+
+    catch(err){
+            res.status(500).json({message:"Internal Server Error"})
+
+    }
+})
+
+router.get('/getAll',userAuth,async (req,res)=>{
+    try{
+        const userId=req.user._id
+        const feedbacks=await ToolFeedback.find({userId}).populate({
+            path: 'checkIn',
+            populate: [
+                { path: 'emotion' },
+                { path: 'activityTag' },
+                { path: 'placeTag' },
+                { path: 'peopleTag' }
+            ]
+        });
+
+
+        res.status(200).json({message:"Fetched All Feedbacks",data:feedbacks})
+    }
+    catch(err){
+        res.status(500).json({message:"Internal Server Error"})
+    }
+})
+module.exports = router;


### PR DESCRIPTION
- Introduced `ToolFeedback` model to store user feedback with tool name, rating, and associated check-in reference.
- Added `/api/feedback` route with endpoints to create (`POST /new`) and fetch all feedbacks (`GET /getAll`).
- Integrated `FeedbackRouter` into the main application.